### PR TITLE
Added -lpthread compile flag

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,5 +11,5 @@ target_link_libraries( ../${CMAKE_PROJECT_NAME} ${Boost_LIBRARIES} )
 # Set default compile flags for GCC
 if(CMAKE_COMPILER_IS_GNUCXX)
   message(STATUS "GCC detected, adding compile flags")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -lpthread")
 endif(CMAKE_COMPILER_IS_GNUCXX)


### PR DESCRIPTION
Lets it compile properly on raspbian. Otherwise got following error:

```
undefined reference to symbol 'pthread_getspecific@@GLIBC_2.4
```
